### PR TITLE
Match deadnames only when surrounded by word boundaries

### DIFF
--- a/src/inject.ts
+++ b/src/inject.ts
@@ -5,7 +5,7 @@ var loaded = false;
 var loadingIntervalFrequency = null;
 var loadedIntervalFrequency = null;
 
-chrome.runtime.sendMessage({}, function() {  
+chrome.runtime.sendMessage({}, function() {
 	if (name === null || deadname === null) {
 		loadNames();
 	} else {
@@ -63,7 +63,7 @@ function changeContent() {
 };
 
 function replaceName(old: string, replacement: string) {
-	const dead = new RegExp(old, "gi");
+	const dead = new RegExp("\\b" + old + "\\b", "gi");
 	document.title = document.title.replace(dead, replacement);
 
 	var elements = document.body.getElementsByTagName("*");
@@ -75,7 +75,7 @@ function replaceName(old: string, replacement: string) {
 			if (child.nodeType === 3) {
 				const text = child.nodeValue;
 				const newText = text.replace(dead, replacement);
-	
+
 				if (newText !== text) {
 					element.replaceChild(document.createTextNode(newText), child);
 				}


### PR DESCRIPTION
Requiring word boundaries when matching fixes #2.

<details>
<summary>Example screenshot from related issue</summary>

![Quote from issue thread. "So let's say a deadname is "REPLACED", it would replace that within "Chat", "Chateau", or "Phosphatase"."](https://user-images.githubusercontent.com/38994283/80441461-ce548c80-88bf-11ea-9453-9932ebe54965.png)

</details>


