### PR TITLE
More inprovements

### DIFF
--- a/src/dom.ts
+++ b/src/dom.ts
@@ -1,0 +1,20 @@
+export function isDOMReady() {
+    return document.readyState === 'complete' || document.readyState === 'interactive';
+}
+
+const readyStateListeners = new Set<() => void>();
+
+export function addDOMReadyListener(listener: () => void) {
+    readyStateListeners.add(listener);
+}
+
+if (!isDOMReady()) {
+    const onReadyStateChange = () => {
+        if (isDOMReady()) {
+            document.removeEventListener('readystatechange', onReadyStateChange);
+            readyStateListeners.forEach((listener) => listener());
+            readyStateListeners.clear();
+        }
+    };
+    document.addEventListener('readystatechange', onReadyStateChange);
+}

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -59,7 +59,6 @@ function changeContent() {
 
 function checkNodeForReplacement(node: Node, dead: RegExp[], replacement: string[]) {
     if (node.nodeType === 3) {
-        console.log(node);
         for (let i = 0, len = dead.length; i < len; i++) {
             const text = node.nodeValue;
             const newText = text.replace(dead[i], replacement[i]);

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -63,7 +63,7 @@ function checkNodeForReplacement(node: Node, dead: RegExp[], replacement: string
             const text = node.nodeValue;
             const newText = text.replace(dead[i], replacement[i]);
             if (newText !== text) {
-                node.parentElement.replaceChild(document.createTextNode(newText), node);
+                node.parentElement && node.parentElement.replaceChild(document.createTextNode(newText), node);
             }
         }
     } else {

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -1,35 +1,34 @@
 import { UserSettings, DEFAULT_SETTINGS } from "./Types";
+import { addDOMReadyListener, isDOMReady } from "./dom";
 
 let alivename = null;
 let deadname = null;
-let loaded = false;
 
 function start() {
-	let disabled = false;
-	chrome.storage.sync.get(DEFAULT_SETTINGS, (sync: UserSettings) => {
-		if (sync.enabled == false) {
-			disabled = true;
-		}
-		if (disabled) {
-			return;
-		}
-		if (name === null || deadname === null) {
-			loadNames();
-		} else {
-			changeContent();
-		}
+    // Some wacky hack to get a click-able link to the inject.js source code in Firefox that don't load side-loaded add-ons in Files.
+    console.log('Starting.');
+    let disabled = false;
+    chrome.storage.sync.get(DEFAULT_SETTINGS, (sync: UserSettings) => {
+        if (sync.enabled == false) {
+            disabled = true;
+        }
+        if (disabled) {
+            return;
+        }
+        if (name === null || deadname === null) {
+            loadNames();
+        } else {
+            changeContent();
+        }
 
-		if (!loaded && document.readyState === "complete") {
-			loaded = true;
-		}
-	});
+    });
 }
 
 function loadNames() {
-	chrome.storage.sync.get(DEFAULT_SETTINGS, function(sync: UserSettings) {
-		alivename = sync.name;
-		deadname = sync.deadname;
-		changeContent();
+    chrome.storage.sync.get(DEFAULT_SETTINGS, function(sync: UserSettings) {
+        alivename = sync.name;
+        deadname = sync.deadname;
+        changeContent();
         return;
     });
 }
@@ -37,63 +36,61 @@ function loadNames() {
 function changeContent() {
   const alivenames = [];
   const deadnames = [];
-	if (alivename.first.length !== 0 && deadname.first.length !== 0 &&
-		alivename.middle.length !== 0 && deadname.middle.length !== 0 &&
-		alivename.last.length !== 0 && deadname.last.length !== 0) {
-			const fullAlive = alivename.first + ' ' + alivename.middle + ' ' + alivename.last;
-			const fullDead = deadname.first + ' ' + deadname.middle + ' ' + deadname.last;
+    if (alivename.first.length !== 0 && deadname.first.length !== 0 &&
+        alivename.middle.length !== 0 && deadname.middle.length !== 0 &&
+        alivename.last.length !== 0 && deadname.last.length !== 0) {
+            const fullAlive = alivename.first + ' ' + alivename.middle + ' ' + alivename.last;
+            const fullDead = deadname.first + ' ' + deadname.middle + ' ' + deadname.last;
       alivenames.push(fullAlive);
       deadnames.push(fullDead);
-	}
-	if (alivename.first.length !== 0 && deadname.first.length !== 0) {
+    }
+    if (alivename.first.length !== 0 && deadname.first.length !== 0) {
     alivenames.push(alivename.first);
     deadnames.push(deadname.first);
-	}
+    }
 
-	if (alivename.last.length !== 0 && deadname.last.length !== 0) {
+    if (alivename.last.length !== 0 && deadname.last.length !== 0) {
     alivenames.push(alivename.last);
     deadnames.push(deadname.last);
-	}
+    }
 
   replaceNames(deadnames, alivenames);
 };
 
 function checkNodeForReplacement(node: Node, dead: RegExp[], replacement: string[]) {
-	if (node.nodeType === 3) {
-    for (let i = 0; i < dead.length; i++) {
-      const text = node.nodeValue;
-      const newText = text.replace(dead[i], replacement[i]);
-
-      if (newText !== text) {
-        node.parentElement.replaceChild(document.createTextNode(newText), node);
-      }
+    if (node.nodeType === 3) {
+        console.log(node);
+        for (let i = 0, len = dead.length; i < len; i++) {
+            const text = node.nodeValue;
+            const newText = text.replace(dead[i], replacement[i]);
+            if (newText !== text) {
+                node.parentElement.replaceChild(document.createTextNode(newText), node);
+            }
+        }
+    } else {
+        if (node.hasChildNodes()) {
+            for (let i = 0, len = node.childNodes.length; i < len; i++) {
+                checkNodeForReplacement(node.childNodes[i], dead, replacement);
+            }
+        }
     }
-	}
 }
 
 function setupListener(dead: RegExp[], replacement: string[]) {
-	const observer = new MutationObserver((mutations: Array<MutationRecord>) => {
-		for (let i = 0, len = mutations.length; i < len; i++) {
-			const mutation: MutationRecord = mutations[i];
-			mutation.addedNodes.forEach((node: Node) =>{
-				checkNodeForReplacement(node, dead, replacement);
-			});
-		}
-	});
-	observer.observe(document, {childList: true, subtree: true});
+    const observer = new MutationObserver((mutations: Array<MutationRecord>) => {
+        for (let i = 0, len = mutations.length; i < len; i++) {
+            const mutation: MutationRecord = mutations[i];
+            if (mutation.type === 'childList') {
+                mutation.addedNodes.forEach((node: Node) => {
+                    checkNodeForReplacement(node, dead, replacement);
+                });
+            }
+        }
+    });
+    observer.observe(document, {childList: true, subtree: true});
 }
 
-
-function replaceNames(old: string[], replacement: string[]) {
-  const dead = [];
-  for (let i = 0; i < old.length; i++) {
-    dead.push(new RegExp("\\b" + old[i] + "\\b", "gi"));
-  }
-
-  for (let i = 0; i < dead.length; i++) {
-    document.title = document.title.replace(dead[i], replacement[i]);
-  }
-
+function checkElementForTextNodes(dead: RegExp[], replacement: string[]) {
 	var elements = document.body.getElementsByTagName("*");
 	for (let i = 0, len = elements.length; i < len; i++) {
 		let element = elements[i];
@@ -102,7 +99,27 @@ function replaceNames(old: string[], replacement: string[]) {
 			checkNodeForReplacement(children[n], dead, replacement);
 		}
 	};
-	setupListener(dead, replacement);
+    setupListener(dead, replacement);
+}
+
+function replaceNames(old: string[], replacement: string[]) {
+    const dead = [];
+    for (let i = 0, len = old.length; i < len; i++) {
+        dead.push(new RegExp("\\b" + old[i] + "\\b", "gi"));
+    }
+    if (!isDOMReady()) {
+        addDOMReadyListener(() => {
+            for (let i = 0, len = dead.length; i < len; i++) {
+                document.title = document.title.replace(dead[i], replacement[i]);
+            }
+            checkElementForTextNodes(dead, replacement);
+        })
+    } else {
+        for (let i = 0, len = dead.length; i < len; i++) {
+            document.title = document.title.replace(dead[i], replacement[i]);
+        }
+        checkElementForTextNodes(dead, replacement);
+    }
 }
 
 start();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,12 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "build",
-    "alwaysStrict": true
+    "alwaysStrict": true,
+    "lib": [
+      "ES2015",
+      "ES2017",
+      "DOM"
+    ]
   },
   "types": [
     "chrome"


### PR DESCRIPTION
- Make sure to have a existing Node that have a parentElement, otherwise it's already been removed and no insertBefore is needed.
- Fix CheckForNode logic by recursive checking ChildrenNodes(That can contain text nodes as well).
- Add a check to not do anything DOM related before the DOM is actually loaded and interactive.
- Add checkElementForTextNodes to do the TextNode finding on inital DOM Loading.
- Add lib as CompilerOption to make sure compatible ES6 functions.
- Fixed some tab/spaces formatting.
- Resolves #76