### PR TITLE
Enable Dependabot implementation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
- Add the dependabot to weekly make PR's to update the NPM Packages.
- Schedule a weekly check so it won't cause any spam on the PR's.
- Added a limit of 5 PR's to even prevent further spam on weekly update.