### PR TITLE
Optimize getting text nodes.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -100,7 +100,7 @@
     "@types/filesystem": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.29.tgz",
-      "integrity": "sha1-7jdI61vhQNz5gMO9NfEa7F96N0g=",
+      "integrity": "sha512-85/1KfRedmfPGsbK8YzeaQUyV1FQAvMPMTuWFQ5EkLd2w7szhNO96bk3Rh/SKmOfd9co2rCLf0Voy4o7ECBOvw==",
       "dev": true,
       "requires": {
         "@types/filewriter": "*"
@@ -115,7 +115,7 @@
     "@types/har-format": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.4.tgz",
-      "integrity": "sha1-MnWEIJWrtg0UtH+nmMyf9wjattQ=",
+      "integrity": "sha512-iUxzm1meBm3stxUMzRqgOVHjj4Kgpgu5w9fm4X7kPRfSgVRzythsucEN7/jtOo8SQzm+HfcxWWzJS0mJDH/3DQ==",
       "dev": true
     },
     "@types/json-schema": {

--- a/src/inject/inject.ts
+++ b/src/inject/inject.ts
@@ -87,16 +87,20 @@ function changeContent() {
 const acceptableCharacters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_';
 
 function replaceText(orginialText: string, oldText: string, newText: string) {
-    let replacementText = orginialText;
+    if (oldText === newText) {
+        return orginialText;
+    }
+    let replacementText = orginialText.slice();
     orginialText = orginialText.toLowerCase();
     oldText = oldText.toLowerCase();
     const oldTextLen = oldText.length;
     let index = orginialText.indexOf(oldText);
     while (index != -1) {
+        const regex = new RegExp(oldText, 'i');
         if (acceptableCharacters.indexOf(orginialText[index + oldTextLen]) === -1 && acceptableCharacters.indexOf(orginialText[index - 1]) === -1) {
-            replacementText = orginialText.replace(oldText, newText);
+            replacementText = replacementText.replace(regex, newText);
         }
-        orginialText = orginialText.replace(oldText, newText);
+        orginialText = orginialText.replace(regex, newText);
         index = orginialText.indexOf(oldText);
     }
     return replacementText;
@@ -144,7 +148,7 @@ function setupListener(dead: string[], replacement: string[]) {
 function checkElementForTextNodes(dead: string[], replacement: string[]) { 2;
     const iterator = document.createNodeIterator(document.body, NodeFilter.SHOW_TEXT);
     let currentTextNode: Node;
-    while ((currentTextNode = iterator.nextNode())) {
+    while (currentTextNode = iterator.nextNode()) {
         checkNodeForReplacement(currentTextNode, dead, replacement);
     }
     if (!revert) {

--- a/src/inject/inject.ts
+++ b/src/inject/inject.ts
@@ -90,7 +90,7 @@ function replaceText(orginialText: string, oldText: string, newText: string) {
     if (oldText === newText) {
         return orginialText;
     }
-    let replacementText = orginialText.slice();
+    let replacementText = orginialText;
     orginialText = orginialText.toLowerCase();
     oldText = oldText.toLowerCase();
     const oldTextLen = oldText.length;

--- a/src/inject/inject.ts
+++ b/src/inject/inject.ts
@@ -90,9 +90,10 @@ function replaceText(orginialText: string, oldText: string, newText: string) {
     let replacementText = orginialText;
     orginialText = orginialText.toLowerCase();
     oldText = oldText.toLowerCase();
-    let index: number = orginialText.indexOf(oldText);
+    const oldTextLen = oldText.length;
+    let index = orginialText.indexOf(oldText);
     while (index != -1) {
-        if (acceptableCharacters.indexOf(orginialText[index + oldText.length]) == -1 && acceptableCharacters.indexOf(orginialText[index - 1]) == -1) {
+        if (acceptableCharacters.indexOf(orginialText[index + oldTextLen]) === -1 && acceptableCharacters.indexOf(orginialText[index - 1]) === -1) {
             replacementText = orginialText.replace(oldText, newText);
         }
         orginialText = orginialText.replace(oldText, newText);
@@ -119,11 +120,9 @@ function checkNodeForReplacement(node: Node, dead: string[], replacement: string
                 node.parentElement && node.parentElement.replaceChild(document.createTextNode(newText), node);
             }
         }
-    } else {
-        if (node.hasChildNodes()) {
-            for (let i = 0, len = node.childNodes.length; i < len; i++) {
-                checkNodeForReplacement(node.childNodes[i], dead, replacement);
-            }
+    } else if (node.hasChildNodes()) {
+        for (let i = 0, len = node.childNodes.length; i < len; i++) {
+            checkNodeForReplacement(node.childNodes[i], dead, replacement);
         }
     }
 }
@@ -142,13 +141,11 @@ function setupListener(dead: string[], replacement: string[]) {
     observer.observe(document, {childList: true, subtree: true});
 }
 
-function checkElementForTextNodes(dead: string[], replacement: string[]) {
-    const elements = document.body.getElementsByTagName('*');
-    for (let i = 0, len = elements.length; i < len; i++) {
-        const children = elements[i].childNodes;
-        for (let n = 0, len2 = children.length; n < len2; n++) {
-            checkNodeForReplacement(children[n], dead, replacement);
-        }
+function checkElementForTextNodes(dead: string[], replacement: string[]) { 2;
+    const iterator = document.createNodeIterator(document.body, NodeFilter.SHOW_TEXT);
+    let currentTextNode: Node;
+    while ((currentTextNode = iterator.nextNode())) {
+        checkNodeForReplacement(currentTextNode, dead, replacement);
     }
     if (!revert) {
         setupListener(dead, replacement);

--- a/tasks/compile-api.js
+++ b/tasks/compile-api.js
@@ -22,7 +22,6 @@ async function api() {
         globalName: 'DeadnameRemover',
         minify: true,
         bundle: true,
-        strict: true,
         sourcemap: false,
     });
 

--- a/tasks/compile-debug.js
+++ b/tasks/compile-debug.js
@@ -11,7 +11,6 @@ async function debug() {
             sourcemap: 'inline',
             format: 'iife',
             bundle: true,
-            strict: true,
             minify: false,
         });
     });

--- a/tasks/compile-production.js
+++ b/tasks/compile-production.js
@@ -11,7 +11,6 @@ async function production() {
             format: 'iife',
             minify: true,
             bundle: true,
-            strict: true,
             sourcemap: false,
         });
     });

--- a/tasks/generate-types.js
+++ b/tasks/generate-types.js
@@ -5,7 +5,6 @@ async function generateType() {
         entryPoints: ['src/types.ts'],
         outfile: 'types.js',
         format: 'cjs',
-        strict: true,
         sourcemap: false,
         minify: false,
         bundle: false,


### PR DESCRIPTION
- Use Treewalker with a text-node filter to get all text nodes.
- Remove `strict` option in ESBuild.
- Cache the length of oldText.
- Fixes bug where the returned text was lowercased.
- Ignore cases where the newText and oldText are the same value.