### PR TITLE
Handle path's with spaces

### DIFF
--- a/tasks/type-checking.js
+++ b/tasks/type-checking.js
@@ -2,7 +2,7 @@ const {exec} = require('child_process');
 
 async function typeCheck() {
     await new Promise((resolve, reject) => {
-        exec(`${process.execPath} ${require.resolve('typescript/lib/tsc.js')} --project "tsconfig.json"`, (err) => {
+        exec(`"${process.execPath}" "${require.resolve('typescript/lib/tsc.js')}" --project "tsconfig.json"`, (err) => {
             if (err) {
                 reject(new Error(`tsc exited with error: ${err}`));
             } else {


### PR DESCRIPTION
- Fixes an issue where the path to `node.exe` had an space in it and will be recognized as an argument.
- Resolves #259